### PR TITLE
Turn left panel buttons into toggles

### DIFF
--- a/javascript/layout.js
+++ b/javascript/layout.js
@@ -502,6 +502,10 @@ function initUI(response) {
         } else {
             dojo.style(dojo.byId("leftPane"), "width", configOptions.leftpanewidth + "px");
         }
+
+        //Hide the panel, so it can be displayed by the upcoming toggle actions
+        hideLeftPanel();
+
         //Add the Editor Button and Panel
         if (configOptions.displayeditor == 'true' || configOptions.displayeditor === true) {
             addEditor(editLayers); //only enabled if map contains editable layers
@@ -681,11 +685,7 @@ function hideLeftPanel() {
     dijit.byId('mainWindow').resize();
     resizeMap();
     //uncheck the edit, detail and legend buttons
-    setTimeout(function () {
-        toggleToolbarButtons('');
-
-    }, 100);
-
+    toggleToolbarButtons('');
 }
 
 function toggleToolbarButtons(label) {

--- a/javascript/layout.js
+++ b/javascript/layout.js
@@ -623,20 +623,6 @@ function resizeMap() {
 
 
 function navigateStack(label) {
-    //display the left panel if its hidden
-    showLeftPanel();
-
-    //select the appropriate container
-    dijit.byId('stackContainer').selectChild(label);
-
-    //hide or show the editor
-    if (label === 'editPanel') {
-        createEditor();
-    } else {
-        destroyEditor();
-    }
-
-    //toggle the other buttons
     var buttonLabel = '';
     switch (label) {
     case 'editPanel':
@@ -649,6 +635,22 @@ function navigateStack(label) {
         buttonLabel = 'detailButton';
         break;
     }
+    var leftPaneWidth = dojo.style(dojo.byId("leftPane"), "width");
+    //Buttons act like toggles to hide/show the panel
+    if (leftPaneWidth > 0 && dijit.byId('stackContainer').selectedChildWidget.id === label) {
+        hideLeftPanel();
+        destroyEditor();
+        buttonLabel = '';
+    } else {
+        showLeftPanel();
+        dijit.byId('stackContainer').selectChild(label);
+        //hide or show the editor
+        if (label === 'editPanel') {
+            createEditor();
+        } else {
+            destroyEditor();
+        }
+    };
     toggleToolbarButtons(buttonLabel);
 }
 


### PR DESCRIPTION
Even though the left panel has a close button, some users expect the buttons that show the panel to also hide the panel (particularly when there is only one button).

This change makes the Legend, Detail and Editor Buttons act like toggles to hide/show
the left panel.  Try it at http://rawgit.com/regan-sarwas/basic-viewer-template/ToggleButtons/index.html

This was tested with a map that had just a legend as well as a map that had a legend and details.  It was _NOT_ tested with the edit button.
